### PR TITLE
Remove unnecessary TaskNotFound handling from insertTask operations

### DIFF
--- a/backend/source/app.d
+++ b/backend/source/app.d
@@ -161,13 +161,6 @@ void postTaskNew(HTTPServerRequest req, HTTPServerResponse res)
 
     Task task;
     try task = db.insertTask(text);
-    catch (TaskNotFound e)
-    {
-        logError(e.toString);
-        Json j = Json(["message": Json("task not found")]);
-        res.writeJsonBody(j, 500);
-        return;
-    }
     catch (Exception e)
     {
         logError(e.toString);

--- a/backend/source/todoapp/dbmanager.d
+++ b/backend/source/todoapp/dbmanager.d
@@ -128,6 +128,7 @@ public:
     }
 
     /// 新規にTODOタスクを登録
+    /// 注意: INSERT操作では TaskNotFound は発生しない（常に新しい行が作成される）
     Task insertTask(string text)
     {
         return doQuery!INSERT_TASK_QUERY(text);


### PR DESCRIPTION
- Remove TaskNotFound catch block in postTaskNew since INSERT operations always create new rows
- Add explanatory comment to insertTask method clarifying that TaskNotFound cannot occur